### PR TITLE
Add editable track artists for non-VA albums and track grid sort sele…

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -42,11 +42,11 @@ class TracksController < ApplicationController
   def index
     @tracks = Track.joins(:user_tracks).where(user_tracks: { user_id: current_user.id })
     @tracks = apply_ext_filters(@tracks).distinct
-      .includes(:artists, :albums, :medium)
-      .sort_by { |track| [track.artists.map { |a| a.name.sub(/^(The|A|An)\s+/i, "") }.min.to_s.downcase, track.albums.map(&:title).min.to_s.downcase, track.title.to_s.downcase] }
+      .includes(:artists, :album_tracks, { albums: :artists }, :medium)
     @user_prefs = current_user.user_tracks
       .includes(:genres, :tags)
       .index_by(&:track_id)
+    @tracks = sort_tracks(@tracks)
 
     render json: { data: @tracks.map { |track|
       pref = @user_prefs[track.id]
@@ -113,6 +113,47 @@ class TracksController < ApplicationController
   end
 
   private
+
+  def sort_tracks(tracks)
+    strip = ->(name) { name.sub(/^(The|A|An)\s+/i, "").downcase }
+
+    case params[:sort]
+    when "album_artist"
+      tracks.sort_by do |t|
+        album = t.albums.min_by { |a| a.title.to_s.downcase }
+        album_artist = album&.artists&.map { |a| strip.call(a.name) }&.min.to_s
+        [album_artist, album&.title.to_s.downcase,
+         t.album_tracks.find { |at| at.album_id == album&.id }&.disc_number.to_i,
+         t.album_tracks.find { |at| at.album_id == album&.id }&.position.to_i,
+         t.title.to_s.downcase]
+      end
+    when "title"
+      tracks.sort_by { |t| strip.call(t.title.to_s) }
+    when "album"
+      tracks.sort_by do |t|
+        album = t.albums.min_by { |a| a.title.to_s.downcase }
+        [album&.title.to_s.downcase,
+         t.album_tracks.find { |at| at.album_id == album&.id }&.disc_number.to_i,
+         t.album_tracks.find { |at| at.album_id == album&.id }&.position.to_i,
+         t.title.to_s.downcase]
+      end
+    when "rating"
+      tracks.sort_by do |t|
+        pref = @user_prefs[t.id]
+        [-(pref&.rating || 0),
+         t.artists.map { |a| strip.call(a.name) }.min.to_s,
+         t.title.to_s.downcase]
+      end
+    when "recent"
+      tracks.sort_by { |t| -t.created_at.to_i }
+    else # "artist" (default)
+      tracks.sort_by do |t|
+        [t.artists.map { |a| strip.call(a.name) }.min.to_s,
+         t.albums.map(&:title).min.to_s.downcase,
+         t.title.to_s.downcase]
+      end
+    end
+  end
 
   def set_track
     @track = Track.find(params[:id])

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -7,20 +7,24 @@
 
 Working branches are created off these for each feature (e.g., `mixtape-develop-20260403_default_listing_order`).
 
-## Recent Changes (Apr 8, 2026) — Album Title Uniqueness Per Artist
+## Recent Changes (Apr 9, 2026) — Editable Track Artists + Track Grid Sort Selector
 
-Deleted duplicate "Movement" album (Album #1, empty — no tracks/genres/tags) that duplicated Album #4 (the real one with 8 tracks). Added `title_unique_per_artist` custom validation to `Album` model to prevent recurrence.
+Made the Artist column editable for all non-VA albums in entry mode (previously VA-only), and added a sort selector dropdown to the Track grid.
 
-- **Backend branch:** `mixtape-develop-20260408_fix_edition_data`
-- **Data cleanup:** Removed 3 UserAlbum records, 1 albums_artists join, and Album #1 via `rails runner`
-- **Validation:** Case-insensitive title uniqueness scoped per artist (non-VA) or across all VA albums (VA). VA and non-VA albums can share a title.
-- **Specs:** 6 model specs + 1 controller spec added (532 total, 0 failures)
+- **Backend branch:** `mixtape-develop-20260409_editable_track_artists_sort_selector`
+- **Frontend branch:** `mixtape-dev-20260409_editable_track_artists_sort_selector`
+- **TracksController:** New `sort_tracks` private method accepting `params[:sort]` with 6 options: `artist` (default), `album_artist`, `title`, `album`, `rating`, `recent`. Updated eager loading to include `{ albums: :artists }` and `:album_tracks` for N+1-safe sorting.
+- **AlbumDetail.js:** Artist column changed from `combobox` (single-select on `artist_name`) to `tagfield` (multi-select on `artist_ids`), matching the genre column pattern.
+- **AlbumController.js:** Removed VA-only restriction on artist editing — now editable for all `is_new` rows in entry mode. Pre-populates `artist_ids`/`artist_name` from album artist for non-VA albums. Updated `onCellEdit` and `onBeforeEdit` for `artist_ids` field. Save handler sends `artist_ids` for all new inline tracks (not just VA).
+- **TrackGrid.js:** Sort combobox added to toolbar (6 sort options).
+- **TrackController.js:** `onSortChange` handler sends `sort` param to backend and reloads store.
+- **Tests:** 18 existing tracks controller specs pass (0 failures).
 
 ## Summary of Earlier Work
 
 For full details on earlier changes, see git history. Key milestones:
 
-- **Apr 8:** Restore missing UserAlbum/UserTrack join records via data migration
+- **Apr 8:** Album title uniqueness validation per artist; restore missing UserAlbum/UserTrack join records
 - **Apr 7:** Sequence and definition columns on all lookup entities (5 backend + 26 frontend files), `remoteSort: false` fix for Ext JS stores
 - **Apr 6:** Simplified per-user lookup ownership (pure per-user model, no system records), no-var code style enforcement
 - **Apr 5:** E2E test coverage expansion (~80 new tests), backend RSpec coverage gaps (420 tests passing), tracklist column visibility, show endpoint for full user track data

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -53,6 +53,7 @@
 - [x] TracksController `track_json` helper with ID arrays (artist_ids, album_ids) and preference data
 - [x] TracksController handles album association via AlbumTrack in create/update
 - [x] TracksController handles `album_ids` array sync via `handle_album_ids_association` (adds/removes AlbumTrack records as unsorted entries)
+- [x] TracksController `sort_tracks` method with 6 sort options (`artist`, `album_artist`, `title`, `album`, `rating`, `recent`) via `params[:sort]`
 
 ### Ext.js Frontend
 - [x] Artist CRUD: ArtistView (border layout), ArtistDetail (form panel), ArtistController (ViewController)


### PR DESCRIPTION
…ctor

TracksController accepts params[:sort] with 6 sort options (artist, album_artist, title, album, rating, recent). Eager loading updated to include albums' artists and album_tracks for N+1-safe sorting. Memory bank updated with feature details.